### PR TITLE
dummy: add dummy plugin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+include: https://gitlab-templates.ddbuild.io/compute-delivery/v1/compute-delivery.yml
+
+stages:
+- verify
+- release
+- notify
+
+.ci:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/compute-delivery:latest
+  stage: verify
+  tags: ["runner:main"]
+
+build:
+  extends: .ci
+  script:
+    - GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name github.user.datadog-compute-robot --with-decryption --query "Parameter.{Value:Value}" --out text)
+    - git config --global url."https://${GITHUB_TOKEN}@github.com/DataDog".insteadOf https://github.com/DataDog
+    - go get github.com/onsi/ginkgo/ginkgo
+    - go get github.com/containernetworking/cni/cnitool
+    - go get golang.org/x/tools/cmd/cover
+    - go get github.com/modocache/gover
+    - go get github.com/mattn/goveralls
+    - ./build_linux.sh

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Read [CONTRIBUTING](CONTRIBUTING.md) for build and test instructions.
 ## Plugins supplied:
 ### Main: interface-creating
 * `bridge`: Creates a bridge, adds the host and the container to it.
+* `dummy`: Creates a dummy interface in a container and add IPs to it.
 * `ipvlan`: Adds an [ipvlan](https://www.kernel.org/doc/Documentation/networking/ipvlan.txt) interface in the container.
 * `loopback`: Set the state of loopback interface to up.
 * `macvlan`: Creates a new MAC address, forwards all traffic to that to the container.

--- a/plugins/main/dummy/README.md
+++ b/plugins/main/dummy/README.md
@@ -1,0 +1,22 @@
+# dummy
+
+CNI plugin to add IP address to the dummy interface of a container's network namespace.
+
+This CNI plugin will create a `dummy0` interface if it does not already exist and add all of the configured IP addresses.
+
+This CNI plugin can be either chained or unchained.
+
+## Configuration
+
+CNI configuration to add `169.254.169.254` to interface `dummy0`.
+
+```json
+{
+    "cniVersion": "0.3.0",
+    "name": "dummy-cni-config",
+    "type": "dummy",
+    "addresses": [
+        "169.254.169.254/32"
+    ]
+}
+```

--- a/plugins/main/dummy/dummy.go
+++ b/plugins/main/dummy/dummy.go
@@ -1,0 +1,237 @@
+// Copyright 2017-2020 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
+	"github.com/vishvananda/netlink"
+)
+
+type PluginConf struct {
+	types.NetConf
+
+	// This is the previous result, when called in the context of a chained
+	// plugin. Because this plugin supports multiple versions, we'll have to
+	// parse this in two passes. If your plugin is not chained, this can be
+	// removed (though you may wish to error if a non-chainable plugin is
+	// chained.
+	RawPrevResult *map[string]interface{} `json:"prevResult"`
+	PrevResult    *current.Result         `json:"-"`
+
+	IfName    string   `json:"ifname"`
+	Addresses []string `json:"addresses"`
+}
+
+// parseConfig parses the supplied configuration (and prevResult) from stdin.
+func parseConfig(stdin []byte) (*PluginConf, error) {
+	conf := PluginConf{}
+
+	if err := json.Unmarshal(stdin, &conf); err != nil {
+		return nil, fmt.Errorf("failed to parse network configuration: %v", err)
+	}
+
+	// Parse previous result. Remove this if your plugin is not chained.
+	if conf.RawPrevResult != nil {
+		resultBytes, err := json.Marshal(conf.RawPrevResult)
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize prevResult: %v", err)
+		}
+		res, err := version.NewResult(conf.CNIVersion, resultBytes)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse prevResult: %v", err)
+		}
+		conf.RawPrevResult = nil
+		conf.PrevResult, err = current.NewResultFromResult(res)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert result to current version: %v", err)
+		}
+	}
+	// End previous result parsing
+
+	if conf.IfName == "" {
+		conf.IfName = "dummy0"
+	}
+
+	if conf.Addresses == nil || len(conf.Addresses) == 0 {
+		return nil, fmt.Errorf("at least one address must be specified")
+	}
+
+	return &conf, nil
+}
+
+// cmdAdd is called for ADD requests
+func cmdAdd(args *skel.CmdArgs) error {
+	conf, err := parseConfig(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	var containerIPs []net.IP
+	if conf.PrevResult != nil {
+		containerIPs := make([]net.IP, 0, len(conf.PrevResult.IPs))
+		// This is some sample code to generate the list of container-side IPs.
+		// We're casting the prevResult to a 0.3.0 response, which can also include
+		// host-side IPs (but doesn't when converted from a 0.2.0 response).
+		//
+		// You don't need this if you are writing an "originating" plugin.
+		if conf.CNIVersion != "0.3.0" {
+			for _, ip := range conf.PrevResult.IPs {
+				containerIPs = append(containerIPs, ip.Address.IP)
+			}
+		} else {
+			for _, ip := range conf.PrevResult.IPs {
+				if ip.Interface == nil {
+					continue
+				}
+				intIdx := *ip.Interface
+				// Every IP is indexed in to the interfaces array, with "-1" standing
+				// for an unknown interface (which we'll assume to be Container-side
+				// Skip all IPs we know belong to an interface with the wrong name.
+				if intIdx >= 0 && intIdx < len(conf.PrevResult.Interfaces) && conf.PrevResult.Interfaces[intIdx].Name != args.IfName {
+					continue
+				}
+				containerIPs = append(containerIPs, ip.Address.IP)
+			}
+		}
+	} else {
+		conf.PrevResult = &current.Result{}
+	}
+
+	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		dummyLink, err := ensureLink(conf.IfName)
+		if err != nil {
+			return err
+		}
+
+		if conf.PrevResult.Interfaces == nil {
+			conf.PrevResult.Interfaces = make([]*current.Interface, 0)
+		}
+
+		linkIndex := len(conf.PrevResult.Interfaces)
+		conf.PrevResult.Interfaces = append(conf.PrevResult.Interfaces, &current.Interface{
+			Name:    dummyLink.Attrs().Name,
+			Mac:     dummyLink.Attrs().HardwareAddr.String(),
+			Sandbox: args.Netns,
+		})
+
+		existingDummyAddrs, err := netlink.AddrList(dummyLink, syscall.AF_INET)
+		if err != nil {
+			return fmt.Errorf("unable to list IP addresses: %v", err)
+		}
+
+		for _, rawAddress := range conf.Addresses {
+			addr, err := netlink.ParseAddr(rawAddress)
+			if err != nil {
+				return fmt.Errorf("unable to parse address: %v", err)
+			}
+
+			for _, cIP := range containerIPs {
+				if cIP.Equal(addr.IP) {
+					return fmt.Errorf("address %v already defined", addr.IP)
+				}
+			}
+
+			if !isIpConfigured(existingDummyAddrs, addr) {
+				err = netlink.AddrAdd(dummyLink, addr)
+				if err != nil {
+					return fmt.Errorf("unable to add address %s to interface %v: %v", addr, dummyLink.Attrs().Name, err)
+				}
+
+				if conf.PrevResult.IPs == nil {
+					conf.PrevResult.IPs = make([]*current.IPConfig, 0)
+				}
+				conf.PrevResult.IPs = append(conf.PrevResult.IPs, &current.IPConfig{
+					Version:   "4",
+					Interface: current.Int(linkIndex),
+					Address: net.IPNet{
+						IP:   addr.IP,
+						Mask: addr.Mask,
+					},
+				})
+			}
+		}
+
+		err = netlink.LinkSetUp(dummyLink)
+		if err != nil {
+			return fmt.Errorf("unable to set link up: %v", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return types.PrintResult(conf.PrevResult, conf.CNIVersion)
+}
+
+func isIpConfigured(addrs []netlink.Addr, addr *netlink.Addr) bool {
+	for _, existingAddr := range addrs {
+		if existingAddr.Equal(*addr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// cmdDel is called for DELETE requests
+func cmdDel(args *skel.CmdArgs) error {
+	// nothing to do here since dummy interface and IPs are assigned in the network namespace
+	// which is destroyed upon delete
+
+	return nil
+}
+
+func main() {
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("dummy"))
+}
+
+func cmdCheck(args *skel.CmdArgs) error {
+	return nil
+}
+
+func ensureLink(linkName string) (netlink.Link, error) {
+	link, err := netlink.LinkByName(linkName)
+	if err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+			return nil, fmt.Errorf("unable to lookup link %s by name: %v", linkName, err)
+		}
+	}
+
+	if link == nil {
+		la := netlink.NewLinkAttrs()
+		la.Name = linkName
+		link = &netlink.Dummy{LinkAttrs: la}
+		err = netlink.LinkAdd(link)
+		if err != nil {
+			return nil, fmt.Errorf("could not add link %s: %v", la.Name, err)
+		}
+
+		return link, nil
+	}
+
+	return link, nil
+}

--- a/plugins/main/dummy/dummy_suite_test.go
+++ b/plugins/main/dummy/dummy_suite_test.go
@@ -1,0 +1,41 @@
+// Copyright 2017-2020 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/onsi/gomega/gexec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+var pathToDummyPlugin string
+
+func TestLoopback(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "plugins/main/dummy")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	pathToDummyPlugin, err = gexec.Build("github.com/containernetworking/plugins/plugins/main/dummy")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -1,0 +1,204 @@
+// Copyright 2017-2020 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Dummy", func() {
+	var (
+		networkNS ns.NetNS
+		command   *exec.Cmd
+		environ   []string
+	)
+
+	BeforeEach(func() {
+		command = exec.Command(pathToDummyPlugin)
+
+		var err error
+		networkNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		environ = []string{
+			fmt.Sprintf("CNI_CONTAINERID=%s", "dummy"),
+			fmt.Sprintf("CNI_NETNS=%s", networkNS.Path()),
+			fmt.Sprintf("CNI_IFNAME=%s", "this is ignored"),
+			fmt.Sprintf("CNI_ARGS=%s", "none"),
+			fmt.Sprintf("CNI_PATH=%s", "/some/test/path"),
+		}
+		command.Stdin = strings.NewReader(`{ "name": "dummy-test", "cniVersion": "0.1.0", "addresses": ["169.254.169.254/32"] }`)
+	})
+
+	AfterEach(func() {
+		Expect(networkNS.Close()).To(Succeed())
+		Expect(testutils.UnmountNS(networkNS)).To(Succeed())
+	})
+
+	Context("when given a network namespace", func() {
+		It("sets the dummy device to UP on ADD", func() {
+			command.Env = append(environ, fmt.Sprintf("CNI_COMMAND=%s", "ADD"))
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gbytes.Say(`{.*}`))
+			Eventually(session).Should(gexec.Exit(0))
+
+			var dummy *net.Interface
+			err = networkNS.Do(func(ns.NetNS) error {
+				var err error
+				dummy, err = net.InterfaceByName("dummy0")
+				return err
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dummy.Flags & net.FlagUp).To(Equal(net.FlagUp))
+		})
+
+		It("allocates addresses on the dummy interface", func() {
+			conf := `{
+				"cniVersion": "0.3.1",
+				"name": "mynet",
+				"type": "dummy",
+				"addresses": [
+					"169.254.169.254/32"
+				]
+			}`
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       networkNS.Path(),
+				IfName:      "eth0",
+				StdinData:   []byte(conf),
+				Args:        "",
+			}
+
+			r, raw, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(*result.Interfaces[0]).To(Equal(
+				current.Interface{
+					Name:    "dummy0",
+					Sandbox: networkNS.Path(),
+				}))
+
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(*result.IPs[0]).To(Equal(
+				current.IPConfig{
+					Version:   "4",
+					Interface: current.Int(0),
+					Address:   mustCIDR("169.254.169.254/32"),
+				}))
+		})
+
+		It("can allocated IPs when chained", func() {
+			conf := `{
+				"cniVersion": "0.3.0",
+				"name": "dummy-cni-test",
+				"type": "dummy",
+				"addresses": [
+					"169.254.169.254/32"
+				],
+				"prevResult": {
+					"interfaces": [
+						{
+							"name": "eth0",
+							"sandbox": "/var/run/netns/test"
+						}
+					],
+					"ips": [
+						{
+							"version": "4",
+							"address": "10.0.0.2/24",
+							"gateway": "10.0.0.1",
+							"interface": 0
+						}
+					],
+					"routes": []
+				}
+			}`
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       networkNS.Path(),
+				IfName:      "eth0",
+				StdinData:   []byte(conf),
+				Args:        "",
+			}
+
+			r, raw, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(2))
+			Expect(*result.Interfaces[1]).To(Equal(
+				current.Interface{
+					Name:    "dummy0",
+					Sandbox: networkNS.Path(),
+				}))
+
+			Expect(len(result.IPs)).To(Equal(2))
+			Expect(*result.IPs[1]).To(Equal(
+				current.IPConfig{
+					Version:   "4",
+					Interface: current.Int(1),
+					Address:   mustCIDR("169.254.169.254/32"),
+				}))
+		})
+
+		It("does not error on DEL", func() {
+			command.Env = append(environ, fmt.Sprintf("CNI_COMMAND=%s", "DEL"))
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gbytes.Say(``))
+			Eventually(session).Should(gexec.Exit(0))
+		})
+	})
+})
+
+func mustCIDR(s string) net.IPNet {
+	ip, n, err := net.ParseCIDR(s)
+	n.IP = ip
+	if err != nil {
+		Fail(err.Error())
+	}
+
+	return *n
+}

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -15,7 +15,7 @@ source ./build_linux.sh
 echo "Running tests"
 
 function testrun {
-    sudo -E bash -c "umask 0; cd ${GOPATH}/src; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} go test $@"
+    bash -c "umask 0; cd ${GOPATH}/src; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} go test $@"
 }
 
 COVERALLS=${COVERALLS:-""}


### PR DESCRIPTION
allows IPs to be added to a dummy interface within a container's network
namespace